### PR TITLE
Nami/bug fix and more tests

### DIFF
--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -96,7 +96,7 @@ class Events {
      * @returns {Page}
      */
     listFirstPage(pageSize = null) {
-        return this.iterator().firstPage(pageSize);
+        return this.iterator().firstPage(null, pageSize);
     }
 
     /**

--- a/src/Subaccounts/SubaccountListParams.js
+++ b/src/Subaccounts/SubaccountListParams.js
@@ -20,26 +20,6 @@ class SubaccountListParams {
         this.filter = filter;
         return this;
     }
-
-    /**
-     * @param {string} tag
-     * @returns {SubaccountListParams}
-     */
-    withTag(tag) {
-        this.tag = tag;
-        return this;
-    }
-
-    /**
-     * @param {boolean} expandEvents
-     * @returns {SubaccountListParams}
-     */
-    withExpandEvents(expandEvents) {
-        if (expandEvents === true) {
-            this.expand = 'events';
-        }
-        return this;
-    }
 }
 
 module.exports = SubaccountListParams;

--- a/src/Subaccounts/SubaccountListParams.js
+++ b/src/Subaccounts/SubaccountListParams.js
@@ -1,15 +1,9 @@
 class SubaccountListParams {
     /**
      * @param {?string} filter
-     * @param {?string} tag
-     * @param {?boolean} expandEvents
      */
-    constructor(filter = null, tag = null, expandEvents = null) {
+    constructor(filter = null) {
         this.filter = filter;
-        this.tag = tag;
-        if (expandEvents === true) {
-            this.expand = 'events';
-        }
     }
 
     /**

--- a/src/Subaccounts/Subaccounts.js
+++ b/src/Subaccounts/Subaccounts.js
@@ -136,22 +136,22 @@ class Subaccounts {
     /**
      * @returns {Page}
      */
-    listFirstPage(pageSize = null) {
-        return this.iterator().firstPage(pageSize);
+    listFirstPage(queryParams = null, pageSize = null) {
+        return this.iterator().firstPage(queryParams, pageSize);
     }
 
     /**
      * @returns {Page}
      */
-    listPageAfter(afterId, pageSize = null) {
-        return this.iterator().pageAfter(afterId, null, pageSize);
+    listPageAfter(afterId, pageSize = null, queryParams = null) {
+        return this.iterator().pageAfter(afterId, queryParams, pageSize);
     }
 
     /**
      * @returns {Page}
      */
-    listPageBefore(beforeId, pageSize = null) {
-        return this.iterator().pageBefore(beforeId, null, pageSize);
+    listPageBefore(beforeId, pageSize = null, queryParams = null) {
+        return this.iterator().pageBefore(beforeId, queryParams, pageSize);
     }
 
     /**

--- a/src/Subaccounts/Subaccounts.js
+++ b/src/Subaccounts/Subaccounts.js
@@ -136,21 +136,21 @@ class Subaccounts {
     /**
      * @returns {Page}
      */
-    listFirstPage(pageSize = null, queryParams = null) {
+    listFirstPage(queryParams = null, pageSize = null) {
         return this.iterator().firstPage(queryParams, pageSize);
     }
 
     /**
      * @returns {Page}
      */
-    listPageAfter(afterId, pageSize = null, queryParams = null) {
+    listPageAfter(afterId, queryParams = null, pageSize = null) {
         return this.iterator().pageAfter(afterId, queryParams, pageSize);
     }
 
     /**
      * @returns {Page}
      */
-    listPageBefore(beforeId, pageSize = null, queryParams = null) {
+    listPageBefore(beforeId, queryParams = null, pageSize = null) {
         return this.iterator().pageBefore(beforeId, queryParams, pageSize);
     }
 

--- a/src/Subaccounts/Subaccounts.js
+++ b/src/Subaccounts/Subaccounts.js
@@ -136,7 +136,7 @@ class Subaccounts {
     /**
      * @returns {Page}
      */
-    listFirstPage(queryParams = null, pageSize = null) {
+    listFirstPage(pageSize = null, queryParams = null) {
         return this.iterator().firstPage(queryParams, pageSize);
     }
 

--- a/tests/events/listFirstPage.test.js
+++ b/tests/events/listFirstPage.test.js
@@ -11,3 +11,18 @@ test('should list events in first page', async () => {
     let retrievedEventKeys = page.items.map((event) => event.key);
     expect(eventKeys.sort()).toEqual(retrievedEventKeys.sort());
 });
+
+test('should list events in first page with page size', async () => {
+    let eventKeys = [];
+    let chart = await client.charts.create();
+    for (let i = 0; i < 20; i++) {
+        let event = await client.events.create(chart.key);
+        eventKeys.push(event.key);
+    }
+
+    let page = await client.events.listFirstPage(5);
+
+    let retrievedEventKeys = page.items.map((event) => event.key);
+    expect(retrievedEventKeys.length).toBe(5);
+    expect(eventKeys.slice(15).sort()).toEqual(retrievedEventKeys.sort());
+});

--- a/tests/subaccounts/filterSubaccounts.test.js
+++ b/tests/subaccounts/filterSubaccounts.test.js
@@ -42,20 +42,20 @@ test('should filter with no results ', async () => {
     expect(retrievedSubaccountKeys).toEqual([]);
 });
 
-test('should should retrieve first page of subaccounts with filter', async () => {
+test('should retrieve first page of subaccounts with filter', async () => {
     let subaccount1 = await client.subaccounts.create('account1');
     let subaccount2 = await client.subaccounts.create('account2');
     let subaccount3 = await client.subaccounts.create('account3');
     await client.subaccounts.create();
 
     let params = new SubaccountListParams().withFilter('account');
-    let page = await client.subaccounts.listFirstPage(null, params);
+    let page = await client.subaccounts.listFirstPage(params);
     let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
 
     expect(retrievedSubaccountKeys.sort).toEqual([subaccount1.secretKey, subaccount2.secretKey, subaccount3.secretKey].sort);
 });
 
-test('should should retrieve page after given subaccount id with filter', async () => {
+test('should retrieve page after given subaccount id with filter', async () => {
     let subaccount1 = await client.subaccounts.create('test-/@/11');
     let subaccount2 = await client.subaccounts.create('test-/@/12');
     let subaccount3 = await client.subaccounts.create('test-/@/33');
@@ -66,7 +66,7 @@ test('should should retrieve page after given subaccount id with filter', async 
     await client.subaccounts.create('test-/@/8');
 
     let params = new SubaccountListParams().withFilter('test-/@/1');
-    let page = await client.subaccounts.listPageAfter(subaccount3.id, null, params);
+    let page = await client.subaccounts.listPageAfter(subaccount3.id, params);
     let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
 
     expect(retrievedSubaccountKeys.sort).toEqual([subaccount1.secretKey, subaccount2.secretKey].sort);
@@ -86,7 +86,7 @@ test('should should retrieve page before given subaccount id with filter', async
 
 
     let params = new SubaccountListParams().withFilter('test-/@/1');
-    let page = await client.subaccounts.listPageBefore(subaccount1.id, null, params);
+    let page = await client.subaccounts.listPageBefore(subaccount1.id, params);
     let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
 
     expect(retrievedSubaccountKeys.sort).toEqual([subaccount2.secretKey, subaccount3.secretKey].sort);

--- a/tests/subaccounts/filterSubaccounts.test.js
+++ b/tests/subaccounts/filterSubaccounts.test.js
@@ -49,7 +49,7 @@ test('should should retrieve first page of subaccounts with filter', async () =>
     await client.subaccounts.create();
 
     let params = new SubaccountListParams().withFilter('account');
-    let page = await client.subaccounts.listFirstPage(params);
+    let page = await client.subaccounts.listFirstPage(null, params);
     let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
 
     expect(retrievedSubaccountKeys.sort).toEqual([subaccount1.secretKey, subaccount2.secretKey, subaccount3.secretKey].sort);

--- a/tests/subaccounts/filterSubaccounts.test.js
+++ b/tests/subaccounts/filterSubaccounts.test.js
@@ -1,5 +1,20 @@
 const SubaccountListParams = require('../../src/Subaccounts/SubaccountListParams.js');
 
+test('should filter subaccounts ', async () => {
+    let retrievedSubaccountKeys = [];
+
+    let subaccount1 = await client.subaccounts.create('account1');
+    await client.subaccounts.create('account2');
+    await client.subaccounts.create('account3');
+
+    let params = new SubaccountListParams().withFilter('account1');
+    for await(let subaccount of client.subaccounts.listAll(params)) {
+        retrievedSubaccountKeys.push(subaccount.secretKey);
+    }
+
+    expect(retrievedSubaccountKeys).toEqual([subaccount1.secretKey]);
+});
+
 test('should filter subaccounts with special characters', async () => {
     let subaccountKeys = [], retrievedSubaccountKeys = [];
 
@@ -14,4 +29,67 @@ test('should filter subaccounts with special characters', async () => {
     }
 
     expect(retrievedSubaccountKeys.length).toEqual(11);
+});
+
+test('should filter with no results ', async () => {
+    let retrievedSubaccountKeys = [];
+
+    let params = new SubaccountListParams().withFilter('account1');
+    for await(let subaccount of client.subaccounts.listAll(params)) {
+        retrievedSubaccountKeys.push(subaccount.secretKey);
+    }
+
+    expect(retrievedSubaccountKeys).toEqual([]);
+});
+
+test('should should retrieve first page of subaccounts with filter', async () => {
+    let subaccount1 = await client.subaccounts.create('account1');
+    let subaccount2 = await client.subaccounts.create('account2');
+    let subaccount3 = await client.subaccounts.create('account3');
+    await client.subaccounts.create();
+
+    let params = new SubaccountListParams().withFilter('account');
+    let page = await client.subaccounts.listFirstPage(params);
+    let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
+
+    expect(retrievedSubaccountKeys.sort).toEqual([subaccount1.secretKey, subaccount2.secretKey, subaccount3.secretKey].sort);
+});
+
+test('should should retrieve page after given subaccount id with filter', async () => {
+    let subaccount1 = await client.subaccounts.create('test-/@/11');
+    let subaccount2 = await client.subaccounts.create('test-/@/12');
+    let subaccount3 = await client.subaccounts.create('test-/@/33');
+    await client.subaccounts.create('test-/@/4');
+    await client.subaccounts.create('test-/@/5');
+    await client.subaccounts.create('test-/@/6');
+    await client.subaccounts.create('test-/@/7');
+    await client.subaccounts.create('test-/@/8');
+
+    let params = new SubaccountListParams().withFilter('test-/@/1');
+    let page = await client.subaccounts.listPageAfter(subaccount3.id, null, params);
+    let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
+
+    expect(retrievedSubaccountKeys.sort).toEqual([subaccount1.secretKey, subaccount2.secretKey].sort);
+    expect(page.previousPageEndsBefore).toEqual(subaccount2.id + "");
+    expect(page.nextPageStartsAfter).toBeNull();
+});
+
+test('should should retrieve page before given subaccount id with filter', async () => {
+    let subaccount1 = await client.subaccounts.create('test-/@/11');
+    let subaccount2 = await client.subaccounts.create('test-/@/12');
+    let subaccount3 = await client.subaccounts.create('test-/@/13');
+    await client.subaccounts.create('test-/@/4');
+    await client.subaccounts.create('test-/@/5');
+    await client.subaccounts.create('test-/@/6');
+    await client.subaccounts.create('test-/@/7');
+    await client.subaccounts.create('test-/@/8');
+
+
+    let params = new SubaccountListParams().withFilter('test-/@/1');
+    let page = await client.subaccounts.listPageBefore(subaccount1.id, null, params);
+    let retrievedSubaccountKeys = page.items.map( subaccount => subaccount.secretKey);
+
+    expect(retrievedSubaccountKeys.sort).toEqual([subaccount2.secretKey, subaccount3.secretKey].sort);
+    expect(page.previousPageEndsBefore).toBeNull();
+    expect(page.nextPageStartsAfter).toEqual(subaccount2.id + "");
 });

--- a/tests/subaccounts/listAllSubaccounts.test.js
+++ b/tests/subaccounts/listAllSubaccounts.test.js
@@ -1,13 +1,13 @@
 test('listAll subaccounts when there are more than 20 subaccounts', async () => {
-    let subaccountKeys = [], retrievedSubaccountKeys = [];
+    let subaccountIds = [], retrievedSubaccountIds = [];
     for (let i = 0; i < 55; i++) {
         let subaccount = await client.subaccounts.create();
-        subaccountKeys.push(subaccount.key);
+        subaccountIds.push(subaccount.id);
     }
 
     for await(let subaccount of client.subaccounts.listAll()) {
-        retrievedSubaccountKeys.push(subaccount.key);
+        retrievedSubaccountIds.push(subaccount.id);
     }
 
-    expect(retrievedSubaccountKeys.sort()).toEqual(subaccountKeys.sort());
+    expect(retrievedSubaccountIds.sort()).toEqual(subaccountIds.sort());
 });

--- a/tests/subaccounts/listFirstPage.test.js
+++ b/tests/subaccounts/listFirstPage.test.js
@@ -1,13 +1,27 @@
 test('should list subaccounts in first page', async () => {
-    let subaccountKeys = [];
+    let subaccountIds = [];
     for (let i = 0; i < 50; i++) {
         let subaccount = await client.subaccounts.create();
-        subaccountKeys.push(subaccount.key);
+        subaccountIds.push(subaccount.id);
     }
 
     let page = await client.subaccounts.listFirstPage();
 
-    let retrievedSubaccountKeys = page.items.map((subaccount) => subaccount.key);
-    expect(subaccountKeys.sort()).toEqual(retrievedSubaccountKeys.sort());
+    let retrievedSubaccountIds = page.items.map((subaccount) => subaccount.id);
+    expect(subaccountIds.sort()).toEqual(retrievedSubaccountIds.sort());
+});
 
+test('should list subaccounts in first page with page size', async () => {
+    let subaccountIds = [];
+    for (let i = 0; i < 50; i++) {
+        let subaccount = await client.subaccounts.create();
+        subaccountIds.push(subaccount.id);
+    }
+
+    let page = await client.subaccounts.listFirstPage(null, 3);
+
+    let retrievedSubaccountIds = page.items.map((subaccount) => subaccount.id);
+    expect([subaccountIds[49], subaccountIds[48], subaccountIds[47]].sort()).toEqual(retrievedSubaccountIds.sort());
+    expect(page.nextPageStartsAfter).toEqual(subaccountIds[47] + '');
+    expect(page.previousPageEndsBefore).toBeNull();
 });

--- a/tests/subaccounts/listFirstPage.test.js
+++ b/tests/subaccounts/listFirstPage.test.js
@@ -18,7 +18,7 @@ test('should list subaccounts in first page with page size', async () => {
         subaccountIds.push(subaccount.id);
     }
 
-    let page = await client.subaccounts.listFirstPage(3, null);
+    let page = await client.subaccounts.listFirstPage(null, 3);
 
     let retrievedSubaccountIds = page.items.map((subaccount) => subaccount.id);
     expect([subaccountIds[49], subaccountIds[48], subaccountIds[47]].sort()).toEqual(retrievedSubaccountIds.sort());

--- a/tests/subaccounts/listFirstPage.test.js
+++ b/tests/subaccounts/listFirstPage.test.js
@@ -18,7 +18,7 @@ test('should list subaccounts in first page with page size', async () => {
         subaccountIds.push(subaccount.id);
     }
 
-    let page = await client.subaccounts.listFirstPage(null, 3);
+    let page = await client.subaccounts.listFirstPage(3, null);
 
     let retrievedSubaccountIds = page.items.map((subaccount) => subaccount.id);
     expect([subaccountIds[49], subaccountIds[48], subaccountIds[47]].sort()).toEqual(retrievedSubaccountIds.sort());

--- a/tests/subaccounts/listPageAfter.test.js
+++ b/tests/subaccounts/listPageAfter.test.js
@@ -14,7 +14,7 @@ test('should list subaccounts after given subaccount id with page size', async (
     let subaccount2 = await client.subaccounts.create();
     let subaccount3 = await client.subaccounts.create();
 
-    let page = await client.subaccounts.listPageAfter(subaccount3.id, 1);
+    let page = await client.subaccounts.listPageAfter(subaccount3.id, null, 1);
 
     expect(page.items[0].id).toEqual(subaccount2.id);
     expect(page.items.length).toBe(1);

--- a/tests/subaccounts/listPageAfter.test.js
+++ b/tests/subaccounts/listPageAfter.test.js
@@ -16,6 +16,6 @@ test('should list subaccounts after given subaccount id with page size', async (
 
     let page = await client.subaccounts.listPageAfter(subaccount3.id, 1);
 
-    expect(page.items[0].secretKey).toEqual(subaccount2.secretKey);
+    expect(page.items[0].id).toEqual(subaccount2.id);
     expect(page.items.length).toBe(1);
 });

--- a/tests/subaccounts/listPageBefore.test.js
+++ b/tests/subaccounts/listPageBefore.test.js
@@ -5,8 +5,8 @@ test('should list subaccounts before given subaccount id', async () => {
 
     let page = await client.subaccounts.listPageBefore(subaccount1.id);
 
-    let subaccountKeys = [page.items[0].secretKey, page.items[1].secretKey];
-    expect(subaccountKeys.sort()).toEqual([subaccount3.secretKey, subaccount2.secretKey].sort());
+    let subaccountKeys = [page.items[0].id, page.items[1].id];
+    expect(subaccountKeys.sort()).toEqual([subaccount3.id, subaccount2.id].sort());
 });
 
 test('should list subaccounts before given subaccount id with page size', async () => {
@@ -16,6 +16,6 @@ test('should list subaccounts before given subaccount id with page size', async 
 
     let page = await client.subaccounts.listPageBefore(subaccount1.id, 1);
 
-    expect(page.items[0].secretKey).toEqual(subaccount2.secretKey);
+    expect(page.items[0].id).toEqual(subaccount2.id);
     expect(page.items.length).toBe(1);
 });

--- a/tests/subaccounts/listPageBefore.test.js
+++ b/tests/subaccounts/listPageBefore.test.js
@@ -14,7 +14,7 @@ test('should list subaccounts before given subaccount id with page size', async 
     let subaccount2 = await client.subaccounts.create();
     await client.subaccounts.create();
 
-    let page = await client.subaccounts.listPageBefore(subaccount1.id, 1);
+    let page = await client.subaccounts.listPageBefore(subaccount1.id, null, 1);
 
     expect(page.items[0].id).toEqual(subaccount2.id);
     expect(page.items.length).toBe(1);


### PR DESCRIPTION
* Removed `withTag` and `withExpandEvents` methods from SubaccountListParams as it was useless 
* Added more tests to filtering (`firstPage`, `listPageAfter`, `listPageBefore`)
* `Subaccount.listFirstPage` had the arguments mixed up. `Lister.firstPage()` accepts queryParameter first, not the pageSize. Same for `Events.listFirstPage`.
* Added additional tests for `Subaccounts.listFirstPage` and `Events.listFirstPage`. 
* Some Subaccount tests were using .key but this property is undefined. Changed those tests to use `id`, (and changed some other that were using secretKey to ID as well)