### PR TITLE
Nami/active inactive subaccounts paginated

### DIFF
--- a/src/Subaccounts/Subaccounts.js
+++ b/src/Subaccounts/Subaccounts.js
@@ -9,8 +9,14 @@ class Subaccounts {
    */
   constructor (client) {
     this.client = client
-    this.active = new AsyncIterator('/subaccounts/active', this.client, 'subaccounts')
-    this.inactive = new AsyncIterator('/subaccounts/inactive', this.client, 'subaccounts')
+    this.active = new Lister('/subaccounts/active', this.client, 'subaccounts', (data) => {
+      let subaccounts = data.items.map((subaccountsData) => utilities.createSubaccount(subaccountsData))
+      return new Page(subaccounts, data.next_page_starts_after, data.previous_page_ends_before)
+    })
+    this.inactive = new Lister('/subaccounts/inactive', this.client, 'subaccounts', (data) => {
+      let subaccounts = data.items.map((subaccountsData) => utilities.createSubaccount(subaccountsData))
+      return new Page(subaccounts, data.next_page_starts_after, data.previous_page_ends_before)
+    })
   }
 
   /**

--- a/tests/subaccounts/listActiveSubaccounts.test.js
+++ b/tests/subaccounts/listActiveSubaccounts.test.js
@@ -11,3 +11,69 @@ test('should list all active subaccounts', async () => {
 
   expect(activeSubaccountIds.sort()).toEqual([subaccount2.id, subaccount1.id].sort())
 })
+
+test('should list first page of active subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+
+  let firstPage = await client.subaccounts.active.firstPage()
+
+  expect(firstPage.items.map(item => item.id).sort()).toEqual([subaccount1.id, subaccount2.id, subaccount3.id].sort())
+  expect(firstPage.items.length).toBe(3)
+})
+
+test('should list first page of active subaccounts with page size', async () => {
+  await client.subaccounts.create()
+  await client.subaccounts.create()
+  let subaccount = await client.subaccounts.create()
+
+  let firstPage = await client.subaccounts.active.firstPage(null, 1)
+
+  expect(firstPage.items[0].id).toEqual(subaccount.id)
+  expect(firstPage.items.length).toBe(1)
+})
+
+test('should list page after of active subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+
+  let pageAfter = await client.subaccounts.active.pageAfter(subaccount3.id)
+
+  expect([pageAfter.items[0].id, pageAfter.items[1].id].sort()).toEqual([subaccount1.id, subaccount2.id].sort())
+  expect(pageAfter.items.length).toBe(2)
+})
+
+test('should list page after of active subaccounts with page size', async () => {
+  await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+
+  let pageAfter = await client.subaccounts.active.pageAfter(subaccount3.id, null, 1)
+
+  expect(pageAfter.items[0].id).toEqual(subaccount2.id)
+  expect(pageAfter.items.length).toBe(1)
+})
+
+test('should list page before of active subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+
+  let pageAfter = await client.subaccounts.active.pageBefore(subaccount1.id)
+
+  expect([pageAfter.items[0].id, pageAfter.items[1].id].sort()).toEqual([subaccount2.id, subaccount3.id].sort())
+  expect(pageAfter.items.length).toBe(2)
+})
+
+test('should list page before of active subaccounts with page size', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  await client.subaccounts.create()
+
+  let pageAfter = await client.subaccounts.active.pageBefore(subaccount1.id, null, 1)
+
+  expect(pageAfter.items[0].id).toEqual(subaccount2.id)
+  expect(pageAfter.items.length).toBe(1)
+})

--- a/tests/subaccounts/listActiveSubaccounts.test.js
+++ b/tests/subaccounts/listActiveSubaccounts.test.js
@@ -5,7 +5,7 @@ test('should list all active subaccounts', async () => {
   await client.subaccounts.deactivate(subaccount3.id)
   let activeSubaccountIds = []
 
-  for await (let subaccount of client.subaccounts.active) {
+  for await (let subaccount of client.subaccounts.active.all()) {
     activeSubaccountIds.push(subaccount.id)
   }
 

--- a/tests/subaccounts/listInactiveSubaccounts.test.js
+++ b/tests/subaccounts/listInactiveSubaccounts.test.js
@@ -6,7 +6,7 @@ test('should list all inactive subaccounts', async () => {
   await client.subaccounts.deactivate(subaccount2.id)
   let inactiveSubaccountIds = []
 
-  for await (let subaccount of client.subaccounts.inactive) {
+  for await (let subaccount of client.subaccounts.inactive.all()) {
     inactiveSubaccountIds.push(subaccount.id)
   }
 

--- a/tests/subaccounts/listInactiveSubaccounts.test.js
+++ b/tests/subaccounts/listInactiveSubaccounts.test.js
@@ -12,3 +12,18 @@ test('should list all inactive subaccounts', async () => {
 
   expect(inactiveSubaccountIds.sort()).toEqual([subaccount1.id, subaccount2.id].sort())
 })
+
+test('should list first page of inactive subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+  await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount1.id)
+  await client.subaccounts.deactivate(subaccount2.id)
+  await client.subaccounts.deactivate(subaccount3.id)
+
+  let firstPage = await client.subaccounts.inactive.firstPage()
+
+  expect(firstPage.items.map(item => item.id).sort()).toEqual([subaccount1.id, subaccount2.id, subaccount3.id].sort())
+  expect(firstPage.items.length).toBe(3)
+})

--- a/tests/subaccounts/listInactiveSubaccounts.test.js
+++ b/tests/subaccounts/listInactiveSubaccounts.test.js
@@ -27,3 +27,67 @@ test('should list first page of inactive subaccounts', async () => {
   expect(firstPage.items.map(item => item.id).sort()).toEqual([subaccount1.id, subaccount2.id, subaccount3.id].sort())
   expect(firstPage.items.length).toBe(3)
 })
+
+test('should list first page of inactive subaccounts with page size', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+  await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount1.id)
+  await client.subaccounts.deactivate(subaccount2.id)
+  await client.subaccounts.deactivate(subaccount3.id)
+
+  let firstPage = await client.subaccounts.inactive.firstPage(null, 2)
+
+  expect(firstPage.items.map(item => item.id).sort()).toEqual([subaccount2.id, subaccount3.id].sort())
+})
+
+test('should list page after of inactive subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount1.id)
+  await client.subaccounts.deactivate(subaccount2.id)
+  await client.subaccounts.deactivate(subaccount3.id)
+
+  let pageAfter = await client.subaccounts.inactive.pageAfter(subaccount3.id)
+
+  expect([pageAfter.items[0].id, pageAfter.items[1].id].sort()).toEqual([subaccount1.id, subaccount2.id].sort())
+})
+
+test('should list page after of inactive subaccounts with page size', async () => {
+  await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount2.id)
+  await client.subaccounts.deactivate(subaccount3.id)
+
+  let pageAfter = await client.subaccounts.inactive.pageAfter(subaccount3.id, null, 1)
+
+  expect(pageAfter.items[0].id).toEqual(subaccount2.id)
+})
+
+test('should list page before of inactive subaccounts', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  let subaccount3 = await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount1.id)
+  await client.subaccounts.deactivate(subaccount2.id)
+  await client.subaccounts.deactivate(subaccount3.id)
+
+  let pageAfter = await client.subaccounts.inactive.pageBefore(subaccount1.id)
+
+  expect([pageAfter.items[0].id, pageAfter.items[1].id].sort()).toEqual([subaccount2.id, subaccount3.id].sort())
+})
+
+test('should list page before of inactive subaccounts with page size', async () => {
+  let subaccount1 = await client.subaccounts.create()
+  let subaccount2 = await client.subaccounts.create()
+  await client.subaccounts.create()
+  await client.subaccounts.deactivate(subaccount1.id)
+  await client.subaccounts.deactivate(subaccount2.id)
+
+  let pageAfter = await client.subaccounts.inactive.pageBefore(subaccount1.id, null, 1)
+
+  expect(pageAfter.items[0].id).toEqual(subaccount2.id)
+})


### PR DESCRIPTION
Noticed that active/inactive subaccounts were still using AsyncIterator instead of Lister.all(), fixed it to be in line with the rest of the clients