### PR TITLE
added methods to validate published and draft charts

### DIFF
--- a/src/Charts/Charts.js
+++ b/src/Charts/Charts.js
@@ -63,6 +63,24 @@ class Charts {
 
   /**
    * @param {string} key
+   * @returns {object}
+   */
+  validatePublishedVersion (key) {
+    return this.client.post(`/charts/${key}/version/published/actions/validate`)
+      .then(res => res.data)
+  }
+
+  /**
+   * @param {string} key
+   * @returns {object}
+   */
+  validateDraftVersion (key) {
+    return this.client.post(`/charts/${key}/version/draft/actions/validate`)
+      .then(res => res.data)
+  }
+
+  /**
+   * @param {string} key
    * @returns {Promise<Chart>} Promise that resolves to a Chart object
    */
   retrieve (key) {

--- a/tests/charts/chartValidation.test.js
+++ b/tests/charts/chartValidation.test.js
@@ -1,0 +1,65 @@
+let testUtils = require('../testUtils.js')
+
+test('should validate published version of a chart', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
+  let chartKey = testUtils.getChartKey()
+  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
+  await client.events.create(chartKey)
+
+  let validationRes = await client.charts.validatePublishedVersion(chartKey)
+
+  let validatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
+  expect(validationRes.errors).toEqual([])
+  expect(validatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validatorKeys).toContain('VALIDATE_FOCAL_POINT')
+  expect(validatorKeys).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+})
+
+test('should validate published version of a chart with different validation settings', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'ERROR')
+  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'ERROR')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'OFF')
+  let chartKey = testUtils.getChartKey()
+  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
+
+  let validationRes = await client.charts.validatePublishedVersion(chartKey)
+
+  let warningValidatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
+  let errorValidatorKeys = validationRes.errors.map(error => error.validatorKey)
+  expect(warningValidatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(warningValidatorKeys).toContain('VALIDATE_FOCAL_POINT')
+  expect(warningValidatorKeys).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+  expect(errorValidatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(errorValidatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(errorValidatorKeys).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+})
+
+test('should validate draft version of a chart', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
+  let chartKey = testUtils.getChartKey()
+  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
+  await client.events.create(chartKey)
+  await client.charts.update(chartKey, 'New name')
+
+  let validationRes = await client.charts.validateDraftVersion(chartKey)
+
+  let validatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
+  expect(validationRes.errors).toEqual([])
+  expect(validatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validatorKeys).toContain('VALIDATE_FOCAL_POINT')
+  expect(validatorKeys).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+})

--- a/tests/charts/chartValidation.test.js
+++ b/tests/charts/chartValidation.test.js
@@ -1,65 +1,15 @@
 let testUtils = require('../testUtils.js')
 
 test('should validate published version of a chart', async () => {
-  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
-  let chartKey = testUtils.getChartKey()
-  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
-  await client.events.create(chartKey)
-
-  let validationRes = await client.charts.validatePublishedVersion(chartKey)
-
-  let validatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
-  expect(validationRes.errors).toEqual([])
-  expect(validatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
-  expect(validatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
-  expect(validatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
-  expect(validatorKeys).toContain('VALIDATE_FOCAL_POINT')
-  expect(validatorKeys).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
-})
-
-test('should validate published version of a chart with different validation settings', async () => {
-  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'ERROR')
-  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'ERROR')
-  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'OFF')
   let chartKey = testUtils.getChartKey()
   await testUtils.createErroneousTestChart(chartKey, user.designerKey)
 
   let validationRes = await client.charts.validatePublishedVersion(chartKey)
 
-  let warningValidatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
-  let errorValidatorKeys = validationRes.errors.map(error => error.validatorKey)
-  expect(warningValidatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
-  expect(warningValidatorKeys).toContain('VALIDATE_FOCAL_POINT')
-  expect(warningValidatorKeys).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
-  expect(errorValidatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
-  expect(errorValidatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
-  expect(errorValidatorKeys).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
-})
-
-test('should validate draft version of a chart', async () => {
-  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
-  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
-  let chartKey = testUtils.getChartKey()
-  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
-  await client.events.create(chartKey)
-  await client.charts.update(chartKey, 'New name')
-
-  let validationRes = await client.charts.validateDraftVersion(chartKey)
-
-  let validatorKeys = validationRes.warnings.map(warning => warning.validatorKey)
-  expect(validationRes.errors).toEqual([])
+  let validatorKeys = validationRes.errors.map(error => error.validatorKey)
+  expect(validationRes.errors.length).toBe(3)
+  expect(validationRes.warnings.length).toBe(0)
   expect(validatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
   expect(validatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
   expect(validatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
-  expect(validatorKeys).toContain('VALIDATE_FOCAL_POINT')
-  expect(validatorKeys).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
 })

--- a/tests/charts/chartValidation.test.js
+++ b/tests/charts/chartValidation.test.js
@@ -6,10 +6,9 @@ test('should validate published version of a chart', async () => {
 
   let validationRes = await client.charts.validatePublishedVersion(chartKey)
 
-  let validatorKeys = validationRes.errors.map(error => error.validatorKey)
   expect(validationRes.errors.length).toBe(3)
   expect(validationRes.warnings.length).toBe(0)
-  expect(validatorKeys).toContain('VALIDATE_DUPLICATE_LABELS')
-  expect(validatorKeys).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
-  expect(validatorKeys).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validationRes.errors).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validationRes.errors).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validationRes.errors).toContain('VALIDATE_UNLABELED_OBJECTS')
 })

--- a/tests/charts/chartValidation.test.js
+++ b/tests/charts/chartValidation.test.js
@@ -1,14 +1,59 @@
 let testUtils = require('../testUtils.js')
 
 test('should validate published version of a chart', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
+  let chartKey = testUtils.getChartKey()
+  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
+  await client.events.create(chartKey)
+
+  let validationRes = await client.charts.validatePublishedVersion(chartKey)
+
+  expect(validationRes.errors).toEqual([])
+  expect(validationRes.warnings).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validationRes.warnings).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validationRes.warnings).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validationRes.warnings).toContain('VALIDATE_FOCAL_POINT')
+  expect(validationRes.warnings).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+})
+
+test('should validate published version of a chart with different validation settings', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'OFF')
   let chartKey = testUtils.getChartKey()
   await testUtils.createErroneousTestChart(chartKey, user.designerKey)
 
   let validationRes = await client.charts.validatePublishedVersion(chartKey)
 
-  expect(validationRes.errors.length).toBe(3)
-  expect(validationRes.warnings.length).toBe(0)
-  expect(validationRes.errors).toContain('VALIDATE_DUPLICATE_LABELS')
-  expect(validationRes.errors).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validationRes.warnings).toContain('VALIDATE_FOCAL_POINT')
+  expect(validationRes.warnings).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validationRes.warnings).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
   expect(validationRes.errors).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validationRes.errors).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validationRes.errors).not.toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
+})
+
+test('should validate draft version of a chart', async () => {
+  await client.accounts.updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_FOCAL_POINT', 'WARNING')
+  await client.accounts.updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING')
+  let chartKey = testUtils.getChartKey()
+  await testUtils.createErroneousTestChart(chartKey, user.designerKey)
+  await client.events.create(chartKey)
+  await client.charts.update(chartKey, 'New name')
+
+  let validationRes = await client.charts.validateDraftVersion(chartKey)
+
+  expect(validationRes.errors).toEqual([])
+  expect(validationRes.warnings).toContain('VALIDATE_DUPLICATE_LABELS')
+  expect(validationRes.warnings).toContain('VALIDATE_OBJECTS_WITHOUT_CATEGORIES')
+  expect(validationRes.warnings).toContain('VALIDATE_UNLABELED_OBJECTS')
+  expect(validationRes.warnings).toContain('VALIDATE_FOCAL_POINT')
+  expect(validationRes.warnings).toContain('VALIDATE_OBJECT_TYPES_PER_CATEGORY')
 })

--- a/tests/sampleChartWithErrors.json
+++ b/tests/sampleChartWithErrors.json
@@ -1,0 +1,444 @@
+{
+  "name": "Sample chart",
+  "tablesLabelCounter": 3,
+  "uuidCounter": 369,
+  "categories": {
+    "list": [
+      {
+        "label": "Cat1",
+        "color": "#87A9CD",
+        "accessible": false,
+        "key": 9
+      },
+      {
+        "label": "Cat2",
+        "color": "#5E42ED",
+        "accessible": false,
+        "key": 10
+      }
+    ],
+    "maxCategoryKey": 10
+  },
+  "version": 17,
+  "venueType": "ROWS_WITHOUT_SECTIONS",
+  "showAllButtons": false,
+  "sectionScaleFactor": 100,
+  "subChart": {
+    "height": 95,
+    "width": 442,
+    "tables": [],
+    "texts": [],
+    "rows": [
+      {
+        "label": "A",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 9,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid288"
+          },
+          {
+            "x": 171.94,
+            "y": 9,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid289"
+          },
+          {
+            "x": 191.94,
+            "y": 9,
+            "label": "?",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid290"
+          },
+          {
+            "x": 211.94,
+            "y": 9,
+            "label": "4",
+            "uuid": "uuid291"
+          },
+          {
+            "x": 231.94,
+            "y": 9,
+            "label": "5",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid292"
+          },
+          {
+            "x": 251.94,
+            "y": 9,
+            "label": "6",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid293"
+          },
+          {
+            "x": 271.94,
+            "y": 9,
+            "label": "7",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid294"
+          },
+          {
+            "x": 291.94,
+            "y": 9,
+            "label": "8",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid295"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid297"
+      },
+      {
+        "label": "B",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 33,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid298"
+          },
+          {
+            "x": 171.94,
+            "y": 33,
+            "label": "2",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid299"
+          },
+          {
+            "x": 191.94,
+            "y": 33,
+            "label": "3",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid300"
+          },
+          {
+            "x": 211.94,
+            "y": 33,
+            "label": "4",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid301"
+          },
+          {
+            "x": 231.94,
+            "y": 33,
+            "label": "5",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid302"
+          },
+          {
+            "x": 251.94,
+            "y": 33,
+            "label": "6",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid303"
+          },
+          {
+            "x": 271.94,
+            "y": 33,
+            "label": "7",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid304"
+          },
+          {
+            "x": 291.94,
+            "y": 33,
+            "label": "8",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid305"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid307"
+      },
+      {
+        "label": "C",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 57,
+            "label": "1",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid308"
+          },
+          {
+            "x": 171.94,
+            "y": 57,
+            "label": "2",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid309"
+          },
+          {
+            "x": 191.94,
+            "y": 57,
+            "label": "3",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid310"
+          },
+          {
+            "x": 211.94,
+            "y": 57,
+            "label": "4",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid311"
+          },
+          {
+            "x": 231.94,
+            "y": 57,
+            "label": "5",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid312"
+          },
+          {
+            "x": 251.94,
+            "y": 57,
+            "label": "6",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid313"
+          },
+          {
+            "x": 271.94,
+            "y": 57,
+            "label": "7",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid314"
+          },
+          {
+            "x": 291.94,
+            "y": 57,
+            "label": "8",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid315"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid317"
+      },
+      {
+        "label": "D",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 81,
+            "label": "1",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid318"
+          },
+          {
+            "x": 171.94,
+            "y": 81,
+            "label": "2",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid319"
+          },
+          {
+            "x": 191.94,
+            "y": 81,
+            "label": "3",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid320"
+          },
+          {
+            "x": 211.94,
+            "y": 81,
+            "label": "4",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid321"
+          },
+          {
+            "x": 231.94,
+            "y": 81,
+            "label": "5",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid322"
+          },
+          {
+            "x": 251.94,
+            "y": 81,
+            "label": "6",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid323"
+          },
+          {
+            "x": 271.94,
+            "y": 81,
+            "label": "7",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid324"
+          },
+          {
+            "x": 291.94,
+            "y": 81,
+            "label": "8",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid325"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid327"
+      }
+    ],
+    "shapes": [],
+    "booths": [],
+    "generalAdmissionAreas": [
+      {
+        "categoryLabel": "Cat1",
+        "categoryKey": 9,
+        "capacity": 100,
+        "label": "GA1",
+        "labelSize": 24,
+        "labelShown": true,
+        "labelHorizontalOffset": 0,
+        "labelVerticalOffset": 0,
+        "objectType": "generalAdmission",
+        "uuid": "uuid368",
+        "type": "circle",
+        "center": {
+          "x": 53.22,
+          "y": 48.89
+        },
+        "rotationAngle": 0,
+        "radius1": 52.222222222222626,
+        "radius2": 45.55555555555566
+      },
+      {
+        "categoryLabel": "Cat2",
+        "categoryKey": 10,
+        "capacity": 100,
+        "label": "34",
+        "labelSize": 24,
+        "labelShown": true,
+        "labelHorizontalOffset": 0,
+        "labelVerticalOffset": 0,
+        "objectType": "generalAdmission",
+        "uuid": "uuid369",
+        "type": "circle",
+        "center": {
+          "x": 389.22,
+          "y": 48.89
+        },
+        "rotationAngle": 0,
+        "radius1": 52.222222222222626,
+        "radius2": 45.55555555555566
+      }
+    ],
+    "sections": [],
+    "snapOffset": {
+      "x": 0.06,
+      "y": 3
+    }
+  }
+}

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -29,6 +29,10 @@ module.exports = {
     await this.createTestChartFromFile('/sampleChart.json', chartKey, designerKey)
   },
 
+  createErroneousTestChart: async function (chartKey, designerKey) {
+    await this.createTestChartFromFile('/sampleChartWithErrors.json', chartKey, designerKey)
+  },
+
   createTestChartWithTables: async function (chartKey, designerKey) {
     await this.createTestChartFromFile('/sampleChartWithTables.json', chartKey, designerKey)
   },


### PR DESCRIPTION
Added two methods `validatePublishedVersion` and `validateDraftVersion`. Also added an erroneous sample chart to use in tests