### PR TITLE
Fix travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - npm run test
   - npm run bundle
 deploy:
+  edge: true
   - provider: npm
     email: namfaldev@gmail.com
     api_key:
@@ -19,6 +20,5 @@ deploy:
     api_key:
         secure: "SPWZynAXE52xkVIRpKbqq28PGcGGM3xMxM3v9r6uhIL89Bwg4bUFDkhfrCUW+Qsk4NNVmpiuO5OXrwDCgZ4rzhqnzyflYbeeQ7WbVh10UizYxDrEMRDEB+v70tE7TydR7QdRyv5uQuvOGuYSnCUfvEN76aqx0FnzpjHDXvt07+ghjm6JE0nMZqigSi4Ge9hISXytH401QD97i+Y67M28v5f/mzjaxTFmNe86y5AoLqin0LMnVqAbGcTKpM9rJW1TSakmEfdpVX7L2KtcxxvytMduOpcnWnaRtQOrTcxz3WpRf1vAXpRM+QXegwR/inhDAreWmtlsMHX3w6QtTm+Vx1yEOjcFTGBKc1lBIReoLyybNuRBTo4rGKGI0u9GwPIADmXYXvTQAIt/+Ypz3c38YBdG69p4Q0oKh9NIhfFgmCrYX4UCYZenVtmbe4UjJfM9+yt0/EeHROGo3oOJD5ePr69bUJlHv6XesUjNjOzzaTsoyb7N2sEIe5kGJVUMRo+d7265yUKblsPVs28gtj1K+lyIzTY2It13nm5BUKb0bfF0a6Gxrj+ox5jOHpA3iQMvBUkEbWuNnebbwrya29y2+E4hejK1ukpZ4zO860p1oYB9JW7c6NXg+rpAUT5CFJHzMDCxBJoqny74joJeyCfqFK+aMIwf0pc0l8czAz8w5Z4="
     file: build/SeatsioClient.js
-    skip_cleanup: true
     on:
         tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - npm run test
   - npm run bundle
 deploy:
-  edge: true
   - provider: npm
     email: namfaldev@gmail.com
     api_key:
@@ -22,3 +21,4 @@ deploy:
     file: build/SeatsioClient.js
     on:
         tags: true
+  edge: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seatsio",
-  "version": "48.0.0",
+  "version": "49.0.0",
   "main": "index.js",
   "description": "Official JavaScript and Node.JS client library for the Seats.io V2 REST API",
   "license": "MIT",


### PR DESCRIPTION
We have not been properly deploying to NPM since v46, apparently dpl v2 became default in January. I think this will fix it, but I am not 100% sure

PS: I removed skip_cleanup true as now in new deployment the flag is `cleanup`, and by default it is false

https://travis-ci.community/t/no-stash-entries-found-missing-api-key-failed-to-deploy/6029

https://docs.travis-ci.com/user/deployment-v2