### PR TITLE
Tests for usage reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           timezone: Europe/Brussels
       - run: yarn test
+        env:
+          DEMO_COMPANY_SECRET_KEY: ${{ secrets.DEMO_COMPANY_SECRET_KEY }}

--- a/src/Reports/UsageReports.ts
+++ b/src/Reports/UsageReports.ts
@@ -19,8 +19,8 @@ export class UsageReports {
             .then(res => res.data)
     }
 
-    detailsForEventInMonth (eventKey: string, month: string) {
-        return this.client.get(`/reports/usage/month/${month}/event/${encodeURIComponent(eventKey)}`)
+    detailsForEventInMonth (eventId: number, month: string) {
+        return this.client.get(`/reports/usage/month/${month}/event/${eventId}`)
             .then(res => res.data)
     }
 

--- a/src/Reports/UsageReports.ts
+++ b/src/Reports/UsageReports.ts
@@ -24,11 +24,6 @@ export class UsageReports {
             .then(res => res.data)
     }
 
-    detailsForObjectInEventInMonth (objectLabel: string, eventKey: string, month: string) {
-        return this.client.get(`/reports/usage/month/${month}/event/${encodeURIComponent(eventKey)}/object/${encodeURIComponent(objectLabel)}`)
-            .then(res => res.data)
-    }
-
     subscription () {
         return this.client.get('/reports/subscription')
             .then(res => res.data)

--- a/tests/reports/chartReports/chartReport.test.ts
+++ b/tests/reports/chartReports/chartReport.test.ts
@@ -1,9 +1,9 @@
-import { TestUtils } from '../testUtils'
-import { IDs } from '../../src/Common/IDs'
-import { ChartObjectInfo } from '../../src/Charts/ChartObjectInfo'
-import { Dict } from '../../src/Dict'
-import { SeatsioClient } from '../../src/SeatsioClient'
-import { Versions } from '../../src/Reports/ChartReports'
+import { TestUtils } from '../../testUtils'
+import { IDs } from '../../../src/Common/IDs'
+import { ChartObjectInfo } from '../../../src/Charts/ChartObjectInfo'
+import { Dict } from '../../../src/Dict'
+import { SeatsioClient } from '../../../src/SeatsioClient'
+import { Versions } from '../../../src/Reports/ChartReports'
 
 describe('chart report properties', () => {
     it.each([

--- a/tests/reports/chartReports/chartReportSummary.test.ts
+++ b/tests/reports/chartReports/chartReportSummary.test.ts
@@ -1,6 +1,6 @@
-import { TestUtils } from '../testUtils'
-import { SeatsioClient } from '../../src/SeatsioClient'
-import { Versions } from '../../src/Reports/ChartReports'
+import { TestUtils } from '../../testUtils'
+import { SeatsioClient } from '../../../src/SeatsioClient'
+import { Versions } from '../../../src/Reports/ChartReports'
 
 describe('summaryByObjectType', () => {
     it.each([

--- a/tests/reports/eventReports/eventReport.test.ts
+++ b/tests/reports/eventReports/eventReport.test.ts
@@ -1,10 +1,10 @@
-import { TestUtils } from '../testUtils'
-import { IDs } from '../../src/Common/IDs'
-import { ObjectProperties } from '../../src/Events/ObjectProperties'
-import { EventObjectInfo } from '../../src/Events/EventObjectInfo'
-import { TableBookingConfig } from '../../src/Events/TableBookingConfig'
-import { CreateEventParams } from '../../src/Events/CreateEventParams'
-import { Channel } from '../../src/Events/Channel'
+import { TestUtils } from '../../testUtils'
+import { IDs } from '../../../src/Common/IDs'
+import { ObjectProperties } from '../../../src/Events/ObjectProperties'
+import { EventObjectInfo } from '../../../src/Events/EventObjectInfo'
+import { TableBookingConfig } from '../../../src/Events/TableBookingConfig'
+import { CreateEventParams } from '../../../src/Events/CreateEventParams'
+import { Channel } from '../../../src/Events/Channel'
 
 test('report properties', async () => {
     const { client, user } = await TestUtils.createTestUserAndClient()

--- a/tests/reports/eventReports/eventReportDeepSummary.test.ts
+++ b/tests/reports/eventReports/eventReportDeepSummary.test.ts
@@ -1,5 +1,5 @@
-import { TestUtils } from '../testUtils'
-import { ObjectProperties } from '../../src/Events/ObjectProperties'
+import { TestUtils } from '../../testUtils'
+import { ObjectProperties } from '../../../src/Events/ObjectProperties'
 
 test('deepSummaryByStatus', async () => {
     const { client, user } = await TestUtils.createTestUserAndClient()

--- a/tests/reports/eventReports/eventReportSummary.test.ts
+++ b/tests/reports/eventReports/eventReportSummary.test.ts
@@ -1,7 +1,7 @@
-import { TestUtils } from '../testUtils'
-import { ObjectProperties } from '../../src/Events/ObjectProperties'
-import { CreateEventParams } from '../../src/Events/CreateEventParams'
-import { Channel } from '../../src/Events/Channel'
+import { TestUtils } from '../../testUtils'
+import { ObjectProperties } from '../../../src/Events/ObjectProperties'
+import { CreateEventParams } from '../../../src/Events/CreateEventParams'
+import { Channel } from '../../../src/Events/Channel'
 
 test('summaryByStatus', async () => {
     const { client, user } = await TestUtils.createTestUserAndClient()

--- a/tests/reports/usageReports/usageReport.test.ts
+++ b/tests/reports/usageReports/usageReport.test.ts
@@ -1,6 +1,10 @@
 import { TestUtils } from '../../testUtils'
 
 test('usage report for all months', async () => {
+    if (!TestUtils.isDemoCompanySecretKeySet()) {
+        return warnAboutDemoCompanySecretKeyNotSet()
+    }
+
     const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
 
     const report = await client.usageReports.summaryForAllMonths()
@@ -11,6 +15,10 @@ test('usage report for all months', async () => {
 })
 
 test('usage report for month', async () => {
+    if (!TestUtils.isDemoCompanySecretKeySet()) {
+        return warnAboutDemoCompanySecretKeyNotSet()
+    }
+
     const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
 
     const report = await client.usageReports.detailsForMonth('2021-11')
@@ -26,6 +34,10 @@ test('usage report for month', async () => {
 })
 
 test('usage report for event in month', async () => {
+    if (!TestUtils.isDemoCompanySecretKeySet()) {
+        return warnAboutDemoCompanySecretKeyNotSet()
+    }
+
     const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
 
     const report = await client.usageReports.detailsForEventInMonth(580293, '2021-11')
@@ -38,3 +50,7 @@ test('usage report for event in month', async () => {
         object: '102-9-14'
     })
 })
+
+function warnAboutDemoCompanySecretKeyNotSet () {
+    console.warn('DEMO_COMPANY_SECRET_KEY environment variable not set, skipping test')
+}

--- a/tests/reports/usageReports/usageReport.test.ts
+++ b/tests/reports/usageReports/usageReport.test.ts
@@ -1,0 +1,40 @@
+import { TestUtils } from '../../testUtils'
+
+test('usage report for all months', async () => {
+    const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
+
+    const report = await client.usageReports.summaryForAllMonths()
+
+    expect(report.usageCutoffDate).toBeTruthy()
+    expect(report.usage.length).toBeGreaterThan(0)
+    expect(report.usage[0].month).toEqual({ month: 2, year: 2014 })
+})
+
+test('usage report for month', async () => {
+    const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
+
+    const report = await client.usageReports.detailsForMonth('2021-11')
+
+    expect(report.length).toBeGreaterThan(0)
+    expect(report[0].usageByChart.length).toBeGreaterThan(0)
+    expect(report[0].usageByChart[0].usageByEvent).toEqual([
+        {
+            numUsedObjects: 143,
+            event: { deleted: false, id: 580293, key: 'largeStadiumEvent' }
+        }
+    ])
+})
+
+test('usage report for event in month', async () => {
+    const client = TestUtils.createClient(TestUtils.demoCompanySecretKey())
+
+    const report = await client.usageReports.detailsForEventInMonth(580293, '2021-11')
+
+    expect(report.length).toBeGreaterThan(0)
+    expect(report[0]).toEqual({
+        numFirstSelections: 1,
+        numFirstBookings: 0,
+        numFirstBookingsOrSelections: 1,
+        object: '102-9-14'
+    })
+})

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -150,4 +150,8 @@ export class TestUtils {
         }
         return demoCompanySecretKey!
     }
+
+    static isDemoCompanySecretKeySet () {
+        return process.env.DEMO_COMPANY_SECRET_KEY !== undefined
+    }
 }

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -142,4 +142,12 @@ export class TestUtils {
         new Category(10, 'Cat2', '#5E42ED', false),
         new Category('string11', 'Cat3', '#5E42BB', false)
     ]
+
+    static demoCompanySecretKey () {
+        const demoCompanySecretKey = process.env.DEMO_COMPANY_SECRET_KEY
+        if (demoCompanySecretKey === undefined) {
+            throw new Error('DEMO_COMPANY_SECRET_KEY must be set')
+        }
+        return demoCompanySecretKey!
+    }
 }


### PR DESCRIPTION
The calls to fetch usage reports (e.g. `client.usageReports.detailsForMonth`) were untested so far. Or rather: only manually tested.

That's because our test companies - which we create in every test - don't have a report yet.

So I added some tests that rely on a `DEMO_COMPANY_SECRET_KEY` environment variable. If it's set, we use that secret key to fetch the usage reports. If not, we just skip the tests.

That secret key will be defined as a secret for GitHub Actions.

I'll do the same in the other API clients, but wanted to get your approval on the general idea.