### PR TITLE
add new method to move an event to a new chart copy

### DIFF
--- a/src/Events/Events.ts
+++ b/src/Events/Events.ts
@@ -178,6 +178,11 @@ export class Events {
         return this.client.delete(`/events/${encodeURIComponent(eventKey)}`)
     }
 
+    moveEventToChartCopy (eventKey: string) {
+        return this.client.post(`events/${encodeURIComponent(eventKey)}/actions/move-to-new-chart-copy`)
+            .then(res => new EventDeserializer().fromJson(res.data))
+    }
+
     listAll (requestParameters = {}) {
         return this.iterator().all(requestParameters)
     }

--- a/tests/events/moveEventToChartCopy.test.ts
+++ b/tests/events/moveEventToChartCopy.test.ts
@@ -1,0 +1,12 @@
+import { TestUtils } from '../testUtils'
+
+test('should move an event to a new chart copy', async () => {
+    const { client } = await TestUtils.createTestUserAndClient()
+    const chart = await client.charts.create()
+    const event = await client.events.create(chart.key)
+
+    const updatedEvent = await client.events.moveEventToChartCopy(event.key)
+
+    expect(updatedEvent.key).toBeTruthy()
+    expect(updatedEvent.chartKey).not.toBe(event.chartKey)
+})


### PR DESCRIPTION
`await client.events.moveEventToChartCopy(event.key)` 