### PR TITLE
Remove update chart key for event

### DIFF
--- a/src/Events/Events.ts
+++ b/src/Events/Events.ts
@@ -139,10 +139,6 @@ export class Events {
     update (eventKey: string, params: UpdateEventParams) {
         const requestParameters: Dict<any> = {}
 
-        if (params.chartKey !== undefined) {
-            requestParameters.chartKey = params.chartKey
-        }
-
         if (params.key !== undefined) {
             requestParameters.eventKey = params.key
         }

--- a/src/Events/UpdateEventParams.ts
+++ b/src/Events/UpdateEventParams.ts
@@ -1,13 +1,7 @@
 import { AbstractEventParams } from './AbstractEventParams'
 
 export class UpdateEventParams extends AbstractEventParams {
-    chartKey?: string
     isInThePast?: boolean
-
-    withChartKey (chartKey: string) {
-        this.chartKey = chartKey
-        return this
-    }
 
     withIsInThePast (isInThePast: boolean) {
         this.isInThePast = isInThePast

--- a/tests/events/updateEvent.test.ts
+++ b/tests/events/updateEvent.test.ts
@@ -6,22 +6,6 @@ import { CreateEventParams } from '../../src/Events/CreateEventParams'
 import { UpdateEventParams } from '../../src/Events/UpdateEventParams'
 import { SeasonParams } from '../../src/Seasons/SeasonParams'
 
-test('should update event\'s chart key', async () => {
-    const { client } = await TestUtils.createTestUserAndClient()
-    const chart1 = await client.charts.create()
-    const chart2 = await client.charts.create()
-    const event = await client.events.create(chart1.key)
-
-    await client.events.update(event.key, new UpdateEventParams().withChartKey(chart2.key))
-
-    const retrievedEvent = await client.events.retrieve(event.key)
-    const now = new Date()
-    expect(retrievedEvent.chartKey).toBe(chart2.key)
-    expect(retrievedEvent.updatedOn).toBeInstanceOf(Date)
-    expect(retrievedEvent.updatedOn!.getTime()).toBeLessThanOrEqual(now.getTime() + 5000)
-    expect(retrievedEvent.updatedOn!.getTime()).toBeGreaterThanOrEqual((now.getTime() - 5000))
-})
-
 test('should update event key', async () => {
     const { client } = await TestUtils.createTestUserAndClient()
     const chart = await client.charts.create()


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `UpdateEventParams`.