### PR TITLE
Fix: timestamp on eventLogItem

### DIFF
--- a/src/EventLog/EventLogItem.ts
+++ b/src/EventLog/EventLogItem.ts
@@ -11,7 +11,7 @@ export class EventLogItem {
     constructor (json: EventLogItemJson) {
         this.id = json.id
         this.type = json.type
-        this.timestamp = new Date(json.date)
+        this.timestamp = new Date(json.timestamp)
         this.data = json.data
     }
 }

--- a/tests/eventLog/listEventLogItems.test.ts
+++ b/tests/eventLog/listEventLogItems.test.ts
@@ -27,7 +27,6 @@ test('properties', async () => {
 
     expect(eventLogItem.id).toBeGreaterThan(0)
     expect(eventLogItem.type).toEqual('chart.created')
-    console.log(eventLogItem.timestamp)
     expect(eventLogItem.timestamp).toBeInstanceOf(Date)
     expect(eventLogItem.timestamp.getTime()).not.toBeNaN()
     expect(eventLogItem.data).toEqual({ key: chart.key, workspaceKey: workspace.key })

--- a/tests/eventLog/listEventLogItems.test.ts
+++ b/tests/eventLog/listEventLogItems.test.ts
@@ -27,6 +27,8 @@ test('properties', async () => {
 
     expect(eventLogItem.id).toBeGreaterThan(0)
     expect(eventLogItem.type).toEqual('chart.created')
-    expect(eventLogItem.timestamp).toBeTruthy()
+    console.log(eventLogItem.timestamp)
+    expect(eventLogItem.timestamp).toBeInstanceOf(Date)
+    expect(eventLogItem.timestamp.getTime()).not.toBeNaN()
     expect(eventLogItem.data).toEqual({ key: chart.key, workspaceKey: workspace.key })
 })


### PR DESCRIPTION
https://trello.com/c/W13PgoBS/8195-fix-timestamp-on-event-log

The timestamp was being incorrectly accessed with `json.date`

Added a more robust test