### PR TITLE
Secret and designer keys no longer in user responses

### DIFF
--- a/src/Users/User.ts
+++ b/src/Users/User.ts
@@ -4,13 +4,11 @@ export type UserJson = Dict<any>
 
 export class User {
     createdOn: Date | null
-    designerKey: string
     email: string
     id: number
     isActive: boolean
     name: string
     role: string
-    secretKey: string
     status: string
     workspaces: any
     nonAdminHasAccessToAllWorkspaces?: boolean
@@ -19,8 +17,6 @@ export class User {
         this.id = json.id
         this.email = json.email
         this.name = json.name
-        this.secretKey = json.secretKey
-        this.designerKey = json.designerKey
         this.role = json.role
         this.createdOn = json.createdOn ? new Date(json.createdOn) : null
         this.isActive = json.isActive

--- a/tests/users/retrieveUser.test.ts
+++ b/tests/users/retrieveUser.test.ts
@@ -5,8 +5,6 @@ test('retrieves a single user', async () => {
     const retrievedUser = await client.users.retrieve(user.id)
 
     expect(retrievedUser.id).toBe(user.id)
-    expect(retrievedUser.secretKey).toBe(user.secretKey)
-    expect(retrievedUser.designerKey).toBe(user.designerKey)
     expect(retrievedUser.email).toBeTruthy()
     expect(retrievedUser.isActive).toBe(true)
     expect(retrievedUser.status).toBe('ACTIVE')


### PR DESCRIPTION
`secretKey` and `designerKey` were removed from some responses in https://github.com/seatsio/seatsio-core-v2/pull/2222

This PR updates the code and tests to match.